### PR TITLE
UI 업데이트

### DIFF
--- a/Jobplanet.xcodeproj/project.pbxproj
+++ b/Jobplanet.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		76B6168C297E2E0A00925D73 /* IdentifiableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B6168B297E2E0A00925D73 /* IdentifiableImageView.swift */; };
 		76B6168E297E397A00925D73 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B6168D297E397A00925D73 /* Error+Extensions.swift */; };
 		76B61690297E400400925D73 /* CellImageDownloadCancelling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B6168F297E400400925D73 /* CellImageDownloadCancelling.swift */; };
+		76BCB059298041BC004E87AD /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76BCB058298041BC004E87AD /* UIApplication+Extensions.swift */; };
 		76E2D893297C10230033F5D1 /* HorizontalThemeCollectionViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E2D892297C10230033F5D1 /* HorizontalThemeCollectionViewCell+Extension.swift */; };
 		76E2D8D2297C2E200033F5D1 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E2D8D1297C2E200033F5D1 /* HomeViewModel.swift */; };
 		76E2D8D4297C3B440033F5D1 /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E2D8D3297C3B440033F5D1 /* Int+Extensions.swift */; };
@@ -174,6 +175,7 @@
 		76B6168B297E2E0A00925D73 /* IdentifiableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableImageView.swift; sourceTree = "<group>"; };
 		76B6168D297E397A00925D73 /* Error+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
 		76B6168F297E400400925D73 /* CellImageDownloadCancelling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageDownloadCancelling.swift; sourceTree = "<group>"; };
+		76BCB058298041BC004E87AD /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		76E2D892297C10230033F5D1 /* HorizontalThemeCollectionViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HorizontalThemeCollectionViewCell+Extension.swift"; sourceTree = "<group>"; };
 		76E2D8D1297C2E200033F5D1 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		76E2D8D3297C3B440033F5D1 /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				761F59C1297BC93F005BE36B /* UILabel+Extensions.swift */,
 				761F59B2297AE3B3005BE36B /* UIView+Extensions.swift */,
 				761F59B4297AE40D005BE36B /* UIViewController+Extensions.swift */,
+				76BCB058298041BC004E87AD /* UIApplication+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -710,6 +713,7 @@
 				761614C4297A6119008CAE86 /* List.swift in Sources */,
 				764AE6D229801A4F00665D5E /* Toast.swift in Sources */,
 				7616148E297A4E72008CAE86 /* HomeViewController.swift in Sources */,
+				76BCB059298041BC004E87AD /* UIApplication+Extensions.swift in Sources */,
 				7648E2AB2980271B00DC6FF3 /* NetworkConnectionManager.swift in Sources */,
 				764AE6CC297FEC4F00665D5E /* CompanyDetailViewModel.swift in Sources */,
 				761F59B5297AE40D005BE36B /* UIViewController+Extensions.swift in Sources */,

--- a/Jobplanet/Base.lproj/Main.storyboard
+++ b/Jobplanet/Base.lproj/Main.storyboard
@@ -122,32 +122,32 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NuS-4I-8eq" customClass="IdentifiableImageView" customModule="Jobplanet" customModuleProvider="target">
-                                <rect key="frame" x="30" y="87" width="45" height="45"/>
+                                <rect key="frame" x="30" y="77" width="58" height="58"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="45" id="4ns-Kq-kIk"/>
+                                    <constraint firstAttribute="width" constant="58" id="4ns-Kq-kIk"/>
                                     <constraint firstAttribute="width" secondItem="NuS-4I-8eq" secondAttribute="height" id="en2-SR-Hhn"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TV2-t8-2Cw">
-                                <rect key="frame" x="95" y="87" width="265" height="20.333333333333329"/>
+                                <rect key="frame" x="100" y="84" width="260" height="20.333333333333329"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pn-yz-e4F">
-                                <rect key="frame" x="95" y="111.33333333333333" width="35.333333333333343" height="16.999999999999986"/>
+                                <rect key="frame" x="100" y="108.33333333333333" width="35.333333333333343" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FUD-ib-XWb">
-                                <rect key="frame" x="30.000000000000004" y="157" width="44.333333333333343" height="21"/>
+                                <rect key="frame" x="30.000000000000004" y="160" width="44.333333333333343" height="21"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fIh-Xo-0XV" customClass="RatingStarsView" customModule="Jobplanet" customModuleProvider="target">
-                                <rect key="frame" x="82.333333333333329" y="158" width="76.999999999999986" height="20"/>
+                                <rect key="frame" x="82.333333333333329" y="161" width="76.999999999999986" height="20"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="ITr-p2-IDd"/>
@@ -155,14 +155,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w0u-gq-j3d" customClass="AppealsView" customModule="Jobplanet" customModuleProvider="target">
-                                <rect key="frame" x="30" y="188" width="330" height="20"/>
+                                <rect key="frame" x="30" y="191" width="330" height="20"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="wZM-D8-COa"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yIt-yq-FtP" customClass="CompanyReviewView" customModule="Jobplanet" customModuleProvider="target">
-                                <rect key="frame" x="30" y="238" width="330" height="260"/>
+                                <rect key="frame" x="30" y="241" width="330" height="260"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="260" id="RSU-AL-yw7"/>
@@ -175,7 +175,7 @@
                             <constraint firstItem="tl1-Hk-nuS" firstAttribute="trailing" secondItem="yIt-yq-FtP" secondAttribute="trailing" constant="30" id="1hF-3j-jzy"/>
                             <constraint firstItem="fIh-Xo-0XV" firstAttribute="bottom" secondItem="FUD-ib-XWb" secondAttribute="bottom" id="3w9-K5-ZHa"/>
                             <constraint firstItem="yIt-yq-FtP" firstAttribute="top" secondItem="w0u-gq-j3d" secondAttribute="bottom" constant="30" id="5bC-Qw-gUF"/>
-                            <constraint firstItem="NuS-4I-8eq" firstAttribute="top" secondItem="tl1-Hk-nuS" secondAttribute="top" constant="40" id="8wo-PF-v2t"/>
+                            <constraint firstItem="NuS-4I-8eq" firstAttribute="top" secondItem="tl1-Hk-nuS" secondAttribute="top" constant="30" id="8wo-PF-v2t"/>
                             <constraint firstItem="tl1-Hk-nuS" firstAttribute="trailing" secondItem="TV2-t8-2Cw" secondAttribute="trailing" constant="30" id="Gyj-Cb-auY"/>
                             <constraint firstItem="w0u-gq-j3d" firstAttribute="leading" secondItem="tl1-Hk-nuS" secondAttribute="leading" constant="30" id="Jn1-3p-5L8"/>
                             <constraint firstItem="w0u-gq-j3d" firstAttribute="top" secondItem="FUD-ib-XWb" secondAttribute="bottom" constant="10" id="R7G-wM-e0y"/>
@@ -186,9 +186,9 @@
                             <constraint firstItem="yIt-yq-FtP" firstAttribute="leading" secondItem="tl1-Hk-nuS" secondAttribute="leading" constant="30" id="gzC-Cg-fpF"/>
                             <constraint firstItem="FUD-ib-XWb" firstAttribute="leading" secondItem="NuS-4I-8eq" secondAttribute="leading" id="ksO-gT-8at"/>
                             <constraint firstItem="3pn-yz-e4F" firstAttribute="top" secondItem="TV2-t8-2Cw" secondAttribute="bottom" constant="4" id="mb5-sf-fEB"/>
-                            <constraint firstItem="TV2-t8-2Cw" firstAttribute="top" secondItem="NuS-4I-8eq" secondAttribute="top" id="tqW-7B-iHS"/>
+                            <constraint firstItem="TV2-t8-2Cw" firstAttribute="top" secondItem="NuS-4I-8eq" secondAttribute="top" constant="7" id="tqW-7B-iHS"/>
                             <constraint firstItem="3pn-yz-e4F" firstAttribute="leading" secondItem="TV2-t8-2Cw" secondAttribute="leading" id="wX1-ID-BEK"/>
-                            <constraint firstItem="TV2-t8-2Cw" firstAttribute="leading" secondItem="NuS-4I-8eq" secondAttribute="trailing" constant="20" id="wXy-6H-xVE"/>
+                            <constraint firstItem="TV2-t8-2Cw" firstAttribute="leading" secondItem="NuS-4I-8eq" secondAttribute="trailing" constant="12" id="wXy-6H-xVE"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Jobplanet/Extensions/UIApplication+Extensions.swift
+++ b/Jobplanet/Extensions/UIApplication+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  UIApplication+Extensions.swift
+//  Jobplanet
+//
+//  Created by Jinhyang Kim on 2023/01/25.
+//
+
+import UIKit
+
+extension UIApplication {
+    var safeAreaInsets: UIEdgeInsets? {
+        return UIApplication.shared
+            .connectedScenes
+            .filter({$0.activationState == .foregroundActive})
+            .map({$0 as? UIWindowScene})
+            .compactMap({$0})
+            .first?.windows
+            .filter({$0.isKeyWindow})
+            .first?
+            .safeAreaInsets
+    }
+}

--- a/Jobplanet/Protocol/Toast.swift
+++ b/Jobplanet/Protocol/Toast.swift
@@ -13,44 +13,7 @@ protocol Toast where Self: UIViewController {
 
 extension Toast {
     func showAndHideToastview(with text: String) {
-        let toastView: ToastView = {
-            let leftPadding: CGFloat = 20
-            let bottomPadding = UIApplication.shared
-                .connectedScenes
-                .filter({$0.activationState == .foregroundActive})
-                .map({$0 as? UIWindowScene})
-                .compactMap({$0})
-                .first?.windows
-                .filter({$0.isKeyWindow})
-                .first?
-                .safeAreaInsets
-                .bottom
-            let screenBounds = UIScreen.main.bounds
-            let toastViewFrame = CGRect(x: leftPadding,
-                                        y: screenBounds.height - (bottomPadding ?? 0) - 100,
-                                        width: screenBounds.width - leftPadding*2,
-                                        height: 50)
-            let toastView = ToastView(frame: toastViewFrame)
-            toastView.alpha = 0
-            toastView.setText(with: text)
-            view.addSubview(toastView)
-            return toastView
-        }()
-        
-        
-        UIView.animate(withDuration: 0.2) {
-            toastView.alpha = 1
-        } completion: { success in
-            guard success else { return }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                UIView.animate(withDuration: 0.2) {
-                    toastView.alpha = 0
-                } completion: { _ in
-                    toastView.removeFromSuperview()
-                }
-            }
-        }
+        ToastView.shared.showToast(with: text, view: view)
     }
 }
 

--- a/Jobplanet/UICollectionViewCell/HorizontalThemeCollectionViewCell.swift
+++ b/Jobplanet/UICollectionViewCell/HorizontalThemeCollectionViewCell.swift
@@ -21,6 +21,16 @@ class HorizontalThemeCollectionViewCell: UICollectionViewCell {
         setupCollectionView()
     }
     
+    override func prepareForReuse() {
+        guard !recruitItems.isEmpty else {
+            return
+        }
+        
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0),
+                                    at: .left,
+                                    animated: false)
+    }
+    
     func setupCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = self

--- a/Jobplanet/UIView/ToastView.swift
+++ b/Jobplanet/UIView/ToastView.swift
@@ -28,11 +28,49 @@ class ToastView: UIView {
         commonInit()
     }
     
+    static let shared: ToastView = {
+        let leftPadding: CGFloat = 20
+        let bottomPadding = UIApplication.shared
+            .connectedScenes
+            .filter({$0.activationState == .foregroundActive})
+            .map({$0 as? UIWindowScene})
+            .compactMap({$0})
+            .first?.windows
+            .filter({$0.isKeyWindow})
+            .first?
+            .safeAreaInsets
+            .bottom
+        let screenBounds = UIScreen.main.bounds
+        let toastViewFrame = CGRect(x: leftPadding,
+                                    y: screenBounds.height - (bottomPadding ?? 0) - 100,
+                                    width: screenBounds.width - leftPadding*2,
+                                    height: 50)
+        let toastView = ToastView(frame: toastViewFrame)
+        toastView.alpha = 0
+        return toastView
+    }()
+    
     func commonInit() {
         backgroundView.makeCornerRounded(radius: 15)
     }
     
-    func setText(with text: String) {
+    func showToast(with text: String, view: UIView) {
         toastLabel.text = text
+        
+        view.addSubview(self)
+        
+        UIView.animate(withDuration: 0.2) {
+            self.alpha = 1
+        } completion: { success in
+            guard success else { return }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                UIView.animate(withDuration: 0.2) {
+                    self.alpha = 0
+                } completion: { _ in
+                    self.removeFromSuperview()
+                }
+            }
+        }
     }
 }

--- a/Jobplanet/UIView/ToastView.swift
+++ b/Jobplanet/UIView/ToastView.swift
@@ -30,19 +30,10 @@ class ToastView: UIView {
     
     static let shared: ToastView = {
         let leftPadding: CGFloat = 20
-        let bottomPadding = UIApplication.shared
-            .connectedScenes
-            .filter({$0.activationState == .foregroundActive})
-            .map({$0 as? UIWindowScene})
-            .compactMap({$0})
-            .first?.windows
-            .filter({$0.isKeyWindow})
-            .first?
-            .safeAreaInsets
-            .bottom
+        let bottomPadding = UIApplication.shared.safeAreaInsets?.bottom ?? 0
         let screenBounds = UIScreen.main.bounds
         let toastViewFrame = CGRect(x: leftPadding,
-                                    y: screenBounds.height - (bottomPadding ?? 0) - 100,
+                                    y: screenBounds.height - bottomPadding - 100,
                                     width: screenBounds.width - leftPadding*2,
                                     height: 50)
         let toastView = ToastView(frame: toastViewFrame)

--- a/Jobplanet/ViewController/CompanyDetailViewController.swift
+++ b/Jobplanet/ViewController/CompanyDetailViewController.swift
@@ -48,6 +48,8 @@ class CompanyDetailViewController: UIViewController, Toast {
         
         // view
         logoImageView.setImage(with: company.logoPath)
+        logoImageView.addBorder(color: .jpGray3, width: 1)
+        logoImageView.makeCornerRounded(radius: 5)
         nameLabel.text = company.name
         ratingLabel.text = "\(company.rateTotalAvg)"
         industryNameLabel.text = company.industryName


### PR DESCRIPTION
## 이슈
https://github.com/TheSongOfSongs/Jobplanet/issues/24
<br/>

## 구현사항
1. **static ToastView 객체 선언**  
기존에는 ToastView를 띄울 때마다 새로 UIView를 생성하여 화면에 띄었습니다. 연속해서 ToastView를 호출하면 계속 쌓이는 이슈가 발생하여 static으로 ToastView를 선언하여 구현했습니다. protocol의 extension에 구현된 메서드에 UIViewController의 view와 label의 text 값을 함께 전달합니다. ToastView는 전달받은 view에 static ToastView를 추가하는 방식으로 동작합니다.
2. 기업' 리스트가 보여진 CollectionView에서 가로 스크롤 CollectionView는 항상 첫 아이템을 보여줍니다.
3. RecruitDetailVC 로고 이미지 뷰 크기를 58x58로 조정했습니다
4. CompanyDetailVC의 로고 이미지 뷰에 테두리를 주고 모서리를 둥글게 변경했습니다