### PR TITLE
네트워크 관련 이슈

### DIFF
--- a/Jobplanet/Network/NetworkService.swift
+++ b/Jobplanet/Network/NetworkService.swift
@@ -86,7 +86,6 @@ extension NetworkService {
         }
         
         currentTask = Task { () -> (Data, URLResponse) in
-            currentTask = nil
             return try await URLSession.shared.data(from: url)
         }
         
@@ -103,6 +102,10 @@ extension NetworkService {
             
             guard response.statusCode == 200 else {
                 return .failure(.failedRequest)
+            }
+            
+            guard !currentTask.isCancelled else {
+                return .failure(.cancelled)
             }
             
             return .success(data)

--- a/Jobplanet/ViewController/HomeViewController.swift
+++ b/Jobplanet/ViewController/HomeViewController.swift
@@ -143,6 +143,7 @@ class HomeViewController: UIViewController, Toast {
             .merge()
             .subscribe(with: self, onNext: { owner, _ in
                 owner.endRefreshing()
+                owner.collectionView.isUserInteractionEnabled = true
             })
             .disposed(by: disposeBag)
         
@@ -151,6 +152,7 @@ class HomeViewController: UIViewController, Toast {
             .asDriver()
             .drive(with: self,
                    onNext: { owner, list in
+                owner.collectionView.isUserInteractionEnabled = false
                 owner.activityIndicatorView.startAnimating()
                 owner.requestItems()
                 owner.cancelImageDownloadingOfCells()

--- a/Jobplanet/ViewController/HomeViewController.swift
+++ b/Jobplanet/ViewController/HomeViewController.swift
@@ -23,7 +23,6 @@ class HomeViewController: UIViewController, Toast {
     let requestCellItems = PublishRelay<Void>()
     let requestItemsBySearching = PublishRelay<(HomeViewModel.SearchCondition)>()
     let listButtonSelected = BehaviorRelay(value: List.recruit)
-    let fetchingEmptyData = PublishRelay<Bool>()
     let disposeBag = DisposeBag()
     
     ///  '채용' 버튼 눌렸을 때 collection view 데이터소스
@@ -100,8 +99,6 @@ class HomeViewController: UIViewController, Toast {
                    onNext: { owner, recruitItems in
                 owner.recruitItems = recruitItems
                 owner.setCollectionViewSize(with: .recruit)
-                owner.endRefreshing()
-                owner.fetchingEmptyData.accept(recruitItems.isEmpty)
             })
             .disposed(by: disposeBag)
         
@@ -109,8 +106,6 @@ class HomeViewController: UIViewController, Toast {
             .drive(with: self, onNext: { owner, cellItems in
                 owner.cellItems = cellItems
                 owner.setCollectionViewSize(with: .cell)
-                owner.endRefreshing()
-                owner.fetchingEmptyData.accept(cellItems.isEmpty)
             })
             .disposed(by: disposeBag)
         
@@ -118,7 +113,6 @@ class HomeViewController: UIViewController, Toast {
             .drive(with: self, onNext: { owner, error in
                 owner.showAndHideToastview(with: error.description)
                 owner.setCollectionViewSize(with: .cell)
-                owner.endRefreshing()
                 
                 if error == .disconnectedNetwork {
                     owner.showWarningLabel(.disconnectedNetwork)
@@ -127,6 +121,32 @@ class HomeViewController: UIViewController, Toast {
             })
             .disposed(by: disposeBag)
         
+        Observable
+            .of(output.cellItems.map({ !$0.isEmpty }),
+                output.recruitItems.map({ !$0.isEmpty }))
+            .merge()
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self, onNext: { owner, isNotEmpty in
+                if isNotEmpty {
+                    owner.warningLabel.isHidden = true
+                    owner.retryButton.isHidden = true
+                } else {
+                    owner.showWarningLabel(.emptyData)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        Observable
+            .of(output.cellItems.map({ _ in Void() }),
+                output.recruitItems.map({ _ in Void() }),
+                output.error.map({ _ in Void() }))
+            .merge()
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.endRefreshing()
+            })
+            .disposed(by: disposeBag)
+        
+        
         listButtonSelected
             .asDriver()
             .drive(with: self,
@@ -134,18 +154,6 @@ class HomeViewController: UIViewController, Toast {
                 owner.activityIndicatorView.startAnimating()
                 owner.requestItems()
                 owner.cancelImageDownloadingOfCells()
-            })
-            .disposed(by: disposeBag)
-        
-        fetchingEmptyData
-            .asDriver(onErrorJustReturn: false)
-            .drive(with: self, onNext: { owner, isEmpty in
-                if isEmpty {
-                    owner.showWarningLabel(.emptyData)
-                } else {
-                    owner.warningLabel.isHidden = true
-                    owner.retryButton.isHidden = true
-                }
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 이슈
https://github.com/TheSongOfSongs/Jobplanet/issues/26
<br/>
## 구현 사항
- NetworkService에서 결과를 반환하기 전, 현재 테스크가 취소되었는지 확인합니다
- 데이터 요청이 들어와 작업을 하는 중, cell을 선택하지 못하도록 collectionView의 속성을 변경하였습니다
- HomeVC에서 채용 아이템, 기업 아이템, 에러 결과값을 받았을 때 RxSwift의 merge 기능으로 묶는 리팩터링 작업을 진행했습니다